### PR TITLE
remove reduced metadata option

### DIFF
--- a/app/src/main/java/xyz/malkki/neostumbler/constants/PreferenceKeys.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/constants/PreferenceKeys.kt
@@ -39,7 +39,6 @@ object PreferenceKeys {
 
     // Privacy options
     const val WIFI_FILTER_LIST = "wifi_filter_list"
-    const val REDUCED_METADATA = "reduced_metadata"
 
     const val USERNAME = "user name"
     const val USER_EMAIL = "user email"

--- a/app/src/main/java/xyz/malkki/neostumbler/ichnaea/ReportSendWorker.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ichnaea/ReportSendWorker.kt
@@ -87,8 +87,7 @@ class ReportSendWorker(appContext: Context, params: WorkerParameters) :
                 reportSaver = reportSaver,
             )
 
-        val sendWithReducedMetadata =
-            settings.getBooleanFlow(PreferenceKeys.REDUCED_METADATA, false).first()
+        val sendWithReducedMetadata = false;
 
         val reupload =
             inputData.hasKeyWithValueOfType<Long>(INPUT_REUPLOAD_FROM) &&

--- a/app/src/main/java/xyz/malkki/neostumbler/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/xyz/malkki/neostumbler/ui/screens/SettingsScreen.kt
@@ -145,13 +145,6 @@ private fun ScanningSettings() {
 private fun PrivacySettings() {
     SettingsGroup(title = stringResource(id = R.string.settings_group_privacy)) {
         WifiFilterSettings()
-
-        SettingsToggle(
-            title = stringResource(id = R.string.reduced_metadata_title),
-            description = stringResource(id = R.string.reduced_metadata_description),
-            preferenceKey = PreferenceKeys.REDUCED_METADATA,
-            default = false,
-        )
     }
 }
 


### PR DESCRIPTION
We don't need the reduced metadata option for the PV+ build. This hides it from the UI and hard-codes the preference to false.